### PR TITLE
【GitHub Actions】デプロイトリガーの調整

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,12 +11,6 @@ on:
       - package-lock.json
 
   workflow_dispatch:
-    inputs:
-      osRunner:
-        default: ubuntu-24.04
-        description: https://github.com/actions/runner-images
-        required: true
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -25,7 +19,7 @@ concurrency:
 jobs:
   preparation:
     if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
-    runs-on: ${{ inputs.osRunner || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     timeout-minutes: 15
@@ -54,7 +48,7 @@ jobs:
         id: zip
         working-directory: build
         env:
-          ZIP_NAME: "mkcmd_${{ steps.meta.outputs.version }}.zip"
+          ZIP_NAME: 'mkcmd_${{ steps.meta.outputs.version }}.zip'
         run: |
           zip -X -r "$ZIP_NAME" .
           echo "name=$ZIP_NAME" >> "$GITHUB_OUTPUT"
@@ -63,7 +57,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.meta.outputs.version }}
-          ZIP_PATH: "build/${{ steps.zip.outputs.name }}"
+          ZIP_PATH: 'build/${{ steps.zip.outputs.name }}'
         run: |
           git tag "$VERSION"
           git push origin "$VERSION"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - released
     paths:
       - package.json
+      - package-lock.json
 
   workflow_dispatch:
     inputs:
@@ -23,7 +24,7 @@ concurrency:
 
 jobs:
   preparation:
-    if: ${{ github.ref_type == 'branch' }}
+    if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ inputs.osRunner || 'ubuntu-24.04' }}
     permissions:
       contents: write


### PR DESCRIPTION
## 概要
* `released` ブランチへのPull Request をClose した際、デプロイが実行されないように修正
    * https://docs.github.com/ja/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
* `pull_request` イベントのパス指定に、バージョン更新すると変更されるファイルパスを追加
* `runs-on` を `ubuntu-24.04` に固定
    * Node.js のため、OS による差異が出にくいと考えられるため