### PR TITLE
npm run deploy した際、何度もビルド前処理をしてしまう問題の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,5 +225,6 @@ $RECYCLE.BIN/
 ### Project ###
 ###############
 build/
+
 src/build.env.ts
 build.env.js

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,9 +29,6 @@
       "name": "update",
       "type": "node",
       "request": "launch",
-      "env": {
-        "TEST_MODE": "true"
-      },
       "program": "${workspaceFolder}/src/update.ts",
       "preLaunchTask": "Debug Build: update",
       "outFiles": ["${workspaceFolder}/build/**/*.js"]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,37 +4,37 @@
   "version": "2.0.0",
   "tasks": [
     {
+      "label": "Configuration",
+      "type": "process",
+      "command": "npm",
+      "args": ["run", "configuration"],
+      "options": {
+        "env": {
+          "DEBUG": "true",
+          "TEST_MODE": "true"
+        }
+      }
+    },
+    {
       "label": "Debug Build: analyze-code-hotspot",
       "type": "process",
       "command": "npm",
       "args": ["run", "build", "analyze-code-hotspot"],
-      "options": {
-        "env": {
-          "DEBUG": "true"
-        }
-      }
+      "dependsOn": ["Configuration"]
     },
     {
       "label": "Debug Build: show-arguments",
       "type": "process",
       "command": "npm",
       "args": ["run", "build", "show-arguments"],
-      "options": {
-        "env": {
-          "DEBUG": "true"
-        }
-      }
+      "dependsOn": ["Configuration"]
     },
     {
       "label": "Debug Build: update",
       "type": "process",
       "command": "npm",
       "args": ["run", "build", "update"],
-      "options": {
-        "env": {
-          "DEBUG": "true"
-        }
-      }
+      "dependsOn": ["Configuration"]
     }
   ]
 }

--- a/build-configuration.js
+++ b/build-configuration.js
@@ -6,11 +6,11 @@ const {major, minor, patch} = require('semver');
 const packageJson = require('./package.json');
 
 /**
- * ビルドの前処理
+ * ビルド前の構築処理
  *
  * @example
  * ``` sh
- * node build.pre.js
+ * node build-configuration.js
  * ```
  */
 async function main() {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "clean": "gts clean",
     "fix": "gts fix",
     "lint": "gts lint",
-    "prebuild": "node build.pre.js",
+    "configuration": "node build-configuration.js",
     "build": "node build.js",
     "build:analyze-code-hotspot": "npm run build analyze-code-hotspot",
     "build:show-arguments": "npm run build show-arguments",
     "build:update": "npm run build update",
-    "deploy": "npm-run-all build:*",
+    "deploy": "npm run configuration && npm-run-all build:*",
     "test": "node --import tsx --test 'src/**/*.test.ts'"
   },
   "devDependencies": {


### PR DESCRIPTION
## 概要
`npm run deploy` すると、コマンド毎に `npm run build` を実行している。

その際 npm の仕様により、 `npm run prebuild` も実行されてしまうので、
1度だけのつもりが何度も実行するようになっていた。

なので本PR で１度のみ実行するように修正した。
